### PR TITLE
docs: update netlify link

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,4 +4,4 @@ NOTE: This repository is under construction and is currently used for testing.
 
 This repository contains a demo page that are built using [@scania/tegel components](https://www.npmjs.com/package/@scania/tegel) and Angular. This is currently under development.
 
-https://main--tegel-angular-demo.netlify.app/
+https://tegel-angular-demo.netlify.app/


### PR DESCRIPTION
Just to update the link for Netlify - one that is maybe a bit easier to remember and aligns with React one.