### PR TITLE
feat(popover-canvas): test referenceEl

### DIFF
--- a/src/app/components/popover-canvas/popover-canvas.component.html
+++ b/src/app/components/popover-canvas/popover-canvas.component.html
@@ -6,13 +6,13 @@
         only-icon
         variant="ghost"
         size="sm"
-        (click)="showPopover = !showPopover"
+        #popoverButton
       >
         <tds-icon slot="icon" class="tds-btn-icon" size="16px" name="kebab"></tds-icon>
       </tds-button>
     </div>
 
-    <tds-popover-canvas placement="top" [show]="showPopover">
+    <tds-popover-canvas placement="top" [referenceEl]="popoverButton">
       <div class="tds-u-p2">
         <h2 class="tds-headline-02 tds-u-mt0">A Popover Canvas!</h2>
         <p class="tds-body-01">Where you can put anything you want!</p>
@@ -23,36 +23,34 @@
         </tds-link>
       </div>
     </tds-popover-canvas>
-
-    <div class="popover-container">
-    <tds-button
-    aria-label="menu"
-    only-icon
-    id="trigger"
-    type="secondary"
-    size="sm"
-  >
-    <tds-icon
-      slot="icon"
-      class="tds-btn-icon"
-      size="16px"
-      name="kebab"
-    ></tds-icon>
-  </tds-button>
-</div>
-<tds-popover-canvas placement="top" selector="#trigger">
-  <div class="tds-u-p2">
-    <h2>A popover canvas!</h2>
-    <p>Where you can put anything you want!</p>
-    <p>
-      <a
-        target="_blank"
-        rel="noopener noreferrer"
-        href="https://tegel.scania.com"
+    
+    <div class="tds-u-flex tds-u-flex-gap-3">
+      <tds-button
+      aria-label="menu"
+      only-icon
+      id="positionReference"
+      type="secondary"
+      size="sm"
       >
-        Tegel Design System
-      </a>
-    </p>
-  </div>
-</tds-popover-canvas>
-  </div>
+        <tds-icon
+          slot="icon"
+          class="tds-btn-icon"
+          size="16px"
+          name="print"
+        ></tds-icon>
+      </tds-button>
+      <tds-toggle size="lg" (tdsToggle)="handleTogglePrinterInformation($event)">
+        <div slot="label">Show printer information</div>
+      </tds-toggle>
+    </div>
+    <!-- Use show when controlling visibility manually, also works when using referenceEl -->
+    <tds-popover-canvas placement="top" selector="#positionReference" [show]="showPrinterInformation">
+      <div class="tds-u-p2">
+        <h2 class="tds-headline-04">Printer Notification</h2>
+        <p>Your document, <em>"Unicorn_Dreams.pdf"</em>, has been queued.</p>
+        <p>Current Status: <strong>In Progress</strong></p>
+        <p>Please await completion. Do not turn off the device.</p>
+        <p>Contact the IT Support, if any errors occur.</p>
+      </div>
+    </tds-popover-canvas>
+</div>

--- a/src/app/components/popover-canvas/popover-canvas.component.html
+++ b/src/app/components/popover-canvas/popover-canvas.component.html
@@ -1,56 +1,77 @@
 <div>
-    <div class="tds-headline-02 tds-u-pb1">Popover Canvas</div>
-    <div class="popover-container">
-      <tds-button
-        aria-label="menu"
-        only-icon
-        variant="ghost"
-        size="sm"
-        #popoverButton
-      >
-        <tds-icon slot="icon" class="tds-btn-icon" size="16px" name="kebab"></tds-icon>
-      </tds-button>
-    </div>
+  <div class="tds-headline-02 tds-u-pb1">Popover Canvas</div>
+  <div class="popover-container">
+    <tds-button
+      aria-label="menu"
+      only-icon
+      variant="ghost"
+      size="sm"
+      #popoverButton
+    >
+      <tds-icon
+        slot="icon"
+        class="tds-btn-icon"
+        size="16px"
+        name="kebab"
+      ></tds-icon>
+    </tds-button>
+  </div>
 
-    <tds-popover-canvas placement="top" [referenceEl]="popoverButton">
-      <div class="tds-u-p2">
-        <h2 class="tds-headline-02 tds-u-mt0">A Popover Canvas!</h2>
-        <p class="tds-body-01">Where you can put anything you want!</p>
-        <tds-link>
-          <a target="_blank" rel="noopener noreferrer" href="https://tegel.scania.com">
-            Even links!
-          </a>
-        </tds-link>
-      </div>
-    </tds-popover-canvas>
-    
-    <div class="tds-u-flex tds-u-flex-gap-3">
-      <tds-button
+  <tds-popover-canvas
+    placement="top"
+    [referenceEl]="popoverButton"
+  >
+    <div class="tds-u-p2">
+      <h2 class="tds-headline-02 tds-u-mt0">A Popover Canvas!</h2>
+      <p class="tds-body-01">Where you can put anything you want!</p>
+      <tds-link>
+        <a
+          target="_blank"
+          rel="noopener noreferrer"
+          href="https://tegel.scania.com"
+        >
+          Even links!
+        </a>
+      </tds-link>
+    </div>
+  </tds-popover-canvas>
+
+  <div class="tds-u-flex tds-u-flex-gap-3">
+    <tds-button
       aria-label="menu"
       only-icon
       id="positionReference"
       type="secondary"
       size="sm"
-      >
-        <tds-icon
-          slot="icon"
-          class="tds-btn-icon"
-          size="16px"
-          name="print"
-        ></tds-icon>
-      </tds-button>
-      <tds-toggle size="lg" (tdsToggle)="handleTogglePrinterInformation($event)">
-        <div slot="label">Show printer information</div>
-      </tds-toggle>
+      disabled
+    >
+      <tds-icon
+        slot="icon"
+        class="tds-btn-icon"
+        size="16px"
+        name="print"
+      ></tds-icon>
+    </tds-button>
+    <tds-toggle
+      size="lg"
+      (tdsToggle)="handleTogglePrinterInformation($event)"
+    >
+      <div slot="label">Show printer information</div>
+    </tds-toggle>
+  </div>
+  <!-- Use show when controlling visibility manually. 
+    Here we use it to hide/show with the toggle instead of the button. -->
+  <tds-popover-canvas
+    placement="top"
+    selector="#positionReference"
+    [show]="showPrinterInformation"
+  >
+    <div class="tds-u-p2">
+      <h2 class="tds-headline-04">Printer Notification</h2>
+      <p>Your document, <em>"Unicorn_Dreams.pdf"</em>, has been queued.</p>
+      <p>Current Status: <strong>In Progress</strong></p>
+      <p>Please await completion. Do not turn off the device.</p>
+      <p>Contact the IT Support, if any errors occur.</p>
     </div>
-    <!-- Use show when controlling visibility manually, also works when using referenceEl -->
-    <tds-popover-canvas placement="top" selector="#positionReference" [show]="showPrinterInformation">
-      <div class="tds-u-p2">
-        <h2 class="tds-headline-04">Printer Notification</h2>
-        <p>Your document, <em>"Unicorn_Dreams.pdf"</em>, has been queued.</p>
-        <p>Current Status: <strong>In Progress</strong></p>
-        <p>Please await completion. Do not turn off the device.</p>
-        <p>Contact the IT Support, if any errors occur.</p>
-      </div>
-    </tds-popover-canvas>
+  </tds-popover-canvas>
 </div>

--- a/src/app/components/popover-canvas/popover-canvas.component.ts
+++ b/src/app/components/popover-canvas/popover-canvas.component.ts
@@ -7,10 +7,12 @@ import { CommonModule } from '@angular/common';
   imports: [CommonModule],
   templateUrl: './popover-canvas.component.html',
   styleUrls: ['./popover-canvas.component.css'],
-  schemas: [CUSTOM_ELEMENTS_SCHEMA]
+  schemas: [CUSTOM_ELEMENTS_SCHEMA],
 })
 export default class PopoverCanvasComponent {
+  showPrinterInformation = false;
 
-  showPopover = false;
-
+  handleTogglePrinterInformation(event: any) {
+    this.showPrinterInformation = event.detail.checked;
+  }
 }

--- a/src/app/components/popover-menu/popover-menu.component.html
+++ b/src/app/components/popover-menu/popover-menu.component.html
@@ -6,18 +6,14 @@
           only-icon
           variant="ghost"
           size="sm"
-          (click)="toggleMenu = !toggleMenu"
           #trigger1
-          id="trigger1"
         >
           <tds-icon slot="icon" class="tds-btn-icon" size="16px" name="kebab"></tds-icon>
         </tds-button>
       </div>
       <tds-popover-menu
         placement="auto"
-        [show]="toggleMenu"
-        #popoverMenu1
-        id="popover-menu-1"
+        [referenceEl]="trigger1"
       >
         <ul class="tds-popover-menu-wrapper">
           <li>

--- a/src/app/components/popover-menu/popover-menu.component.ts
+++ b/src/app/components/popover-menu/popover-menu.component.ts
@@ -7,18 +7,6 @@ import { CommonModule } from '@angular/common';
   imports: [CommonModule],
   templateUrl: './popover-menu.component.html',
   styleUrls: ['./popover-menu.component.css'],
-  schemas: [CUSTOM_ELEMENTS_SCHEMA]
+  schemas: [CUSTOM_ELEMENTS_SCHEMA],
 })
-
-export default class PopoverMenuComponent {
-  
-  toggleMenu = false;
-
-}
-
-
- 
-
- 
-
- 
+export default class PopoverMenuComponent {}


### PR DESCRIPTION
Verified that it works and made a code example on how it is intended to be used.

Note that `referenceEl` is an alternative to `selector` not an alternative to `show`.

It is a way to specify which element should serve as the reference for the popovers position, as well as show/hide the popover on click.

`show` is an alternative way to control visibility of the popover, but the popover still needs to have an element to position itself against.


With referenceEl in angular we get type safety. Nothing is needed in the js file.
![Screenshot 2023-08-23 at 14 55 32](https://github.com/scania-digital-design-system/tegel-angular-demo/assets/8556022/20b1fec6-faf7-45a2-afed-94f11ff91247)

