### PR TITLE
fix: angular router wildcard

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -214,7 +214,7 @@
         <div class="tds-u-h-100">
           <div
             class="switcher-container"
-            *ngIf="!is404Page()"
+            *ngIf="!is404page"
           >
             <app-mode-switcher (modeToggle)="handleModeToggle()"></app-mode-switcher>
             <app-mode-variant-switcher
@@ -222,11 +222,11 @@
             ></app-mode-variant-switcher>
           </div>
           <div class="tds-u-h-100 tds-u-flex tds-u-flex-dir-col">
-            <nav-breadcrumbs *ngIf="!is404Page()"></nav-breadcrumbs>
+            <nav-breadcrumbs *ngIf="!is404page"></nav-breadcrumbs>
 
             <div
               [ngClass]="
-                is404Page()
+                is404page
                   ? 'tds-u-h-100'
                   : 'main-container tds-u-pl3 tds-u-pr3 tds-u-pb3 tds-u-relative'
               "

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,6 +1,6 @@
 import {  Component, OnDestroy, OnInit } from '@angular/core';
 import { FooterComponent } from "@components/footer/footer.component";
-import { Router, RouterOutlet, RouterLink, ActivatedRoute } from '@angular/router';
+import { Router, RouterOutlet, RouterLink, ActivatedRoute, NavigationEnd } from '@angular/router';
 import { ModeSwitcherComponent } from './mode-switcher/mode-switcher.component';
 import { ModeVariantSwitcherComponent } from './mode-variant-switcher/mode-variant-switcher.component';
 import BreadcrumbsComponent from './navigation/breadcrumbs/breadcrumbs.component';
@@ -29,7 +29,23 @@ import { TegelModule } from '@scania/tegel-angular';
   ],
 })
 export class AppComponent implements OnInit, OnDestroy {
-  constructor(private router: Router, private route: ActivatedRoute, private userStoreService: UserStoreService) {}
+  constructor(private router: Router, private route: ActivatedRoute, private userStoreService: UserStoreService) {
+    this.router.events.subscribe((event) => {
+      if (event instanceof NavigationEnd) {
+        let currentRoute = this.route.root;
+        while (currentRoute.children[0] !== undefined) {
+          currentRoute = currentRoute.children[0];
+        }
+        const routeUrl = currentRoute.snapshot.routeConfig?.path;
+
+        if (routeUrl === '**') {
+          this.is404page = true;
+        } else {
+          this.is404page = false;
+        }
+      }
+    });
+  }
   private onDestroy$: Subject<void> = new Subject<void>();
 
   title = 'Angular Demo';
@@ -40,6 +56,7 @@ export class AppComponent implements OnInit, OnDestroy {
   userName = '';
   placeOfWork = '';
   notifications: Notification[];
+  is404page: boolean = false;
 
   isActive(url: string): boolean {
     return this.router.url === url;
@@ -62,11 +79,6 @@ export class AppComponent implements OnInit, OnDestroy {
 
   handleModeToggle() {
     this.mode = this.mode === 'tds-mode-light' ? 'tds-mode-dark' : 'tds-mode-light';
-  }
-
-  is404Page(): boolean {
-    // Check if the current route corresponds to the 404 page
-    return this.router.url === '/404';
   }
 
   ngOnInit() {

--- a/src/app/components/popover-menu/popover-menu.component.html
+++ b/src/app/components/popover-menu/popover-menu.component.html
@@ -23,36 +23,54 @@
     placement="auto"
     selector="#popover-menu-button-a"
   >
-    <tds-popover-menu-item>
-      <a href="tegel.scania.com">Action</a>
-    </tds-popover-menu-item>
-    <tds-divider></tds-divider>
-    <tds-popover-menu-item>
-      <a href="tegel.scania.com">Action</a>
-    </tds-popover-menu-item>
-    <tds-popover-menu-item>
-      <a href="tegel.scania.com">Action</a>
-    </tds-popover-menu-item>
-    <tds-popover-menu-item disabled>
-      <button>Action</button>
-    </tds-popover-menu-item>
-    <tds-divider></tds-divider>
-    <tds-popover-menu-item>
-      <a href="tegel.scania.com">Action</a>
-    </tds-popover-menu-item>
-    <tds-popover-menu-item>
-      <a href="tegel.scania.com">Action</a>
-    </tds-popover-menu-item>
-    <tds-popover-menu-item>
-      <a href="tegel.scania.com">Action</a>
-    <tds-divider></tds-divider>
-    <tds-popover-menu-item>
-      <a href="tegel.scania.com">Action</a>
-    </tds-popover-menu-item>
-    <tds-popover-menu-item>
-      <button>Action</button>
-    </tds-popover-menu-item>
-  
+  <tds-popover-menu-item>
+    <a href="tegel.scania.com">Action</a>
+  </tds-popover-menu-item>
+  <tds-divider></tds-divider>
+  <tds-popover-menu-item>
+    <a href="tegel.scania.com">Action</a>
+  </tds-popover-menu-item>
+  <tds-popover-menu-item>
+    <a href="tegel.scania.com">Action</a>
+  </tds-popover-menu-item>
+  <tds-popover-menu-item disabled>
+    <button>Action</button>
+  </tds-popover-menu-item>
+  <tds-divider></tds-divider>
+  <tds-popover-menu-item>
+    <a href="tegel.scania.com">Action</a>
+  </tds-popover-menu-item>
+  <tds-popover-menu-item>
+    <a href="tegel.scania.com">Action</a>
+  </tds-popover-menu-item>
+  <tds-popover-menu-item>
+    <a href="tegel.scania.com">Action</a>
+  </tds-popover-menu-item>
+  <tds-divider></tds-divider>
+  <tds-popover-menu-item>
+    <a href="tegel.scania.com">Action</a>
+  </tds-popover-menu-item>
+  <tds-popover-menu-item>
+    <button>Action</button>
+  </tds-popover-menu-item>
+</tds-popover-menu>
+
+
+  <div class="popover-container">
+    <tds-button
+      id="triggerElement"
+      aria-label="menu"
+      only-icon
+      size="sm"
+    >
+      <tds-icon
+        slot="icon"
+        class="tds-btn-icon"
+        size="16px"
+        name="kebab"
+      ></tds-icon>
+    </tds-button>
+  </div>
   <tds-popover-menu
     fluid-width
     placement="auto"

--- a/src/app/routes/app-routing.module.ts
+++ b/src/app/routes/app-routing.module.ts
@@ -65,12 +65,8 @@ const routes = [
     loadComponent: () => import('@pages/notifications-page/notifications-page.component'),
   },
   {
-    path: '404',
-    loadComponent: () => import('@pages/error-page/error-page.component'),
-  },
-  {
     path: '**',
-    redirectTo: '404',
+    loadComponent: () => import('@pages/error-page/error-page.component'),
     pathMatch: 'full',
   }, // Wildcard route
 ] satisfies Routes;


### PR DESCRIPTION
This PR adds a route endpoint for wildcard routes - `**`

Fixes: https://tegel.atlassian.net/browse/CDEP-2528

**How to test:**
1. Go to the preview page
2. Enter an invalid URL endpoint, ex: {URL}/asdasdasda
3. Make sure you land on the error page, and that it looks as i should
4. Try navigating to all other pages
5. Make sure the look as before.