### PR TITLE
fix: small readme update

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,6 @@
 
 NOTE: This repository is under construction and is currently used for testing.
 
-This repository contains a demo page that are built using [@scania/tegel] (https://www.npmjs.com/package/@scania/tegel) components and Angular. This is currently under development.
+This repository contains a demo page that are built using [@scania/tegel](https://www.npmjs.com/package/@scania/tegel) components and Angular. This is currently under development.
 
 https://tegel-angular-demo.netlify.app/

--- a/README.md
+++ b/README.md
@@ -2,6 +2,6 @@
 
 NOTE: This repository is under construction and is currently used for testing.
 
-This repository contains a demo page that are built using [@scania/tegel components](https://www.npmjs.com/package/@scania/tegel) and Angular. This is currently under development.
+This repository contains a demo page that are built using [@scania/tegel] (https://www.npmjs.com/package/@scania/tegel) components and Angular. This is currently under development.
 
 https://tegel-angular-demo.netlify.app/


### PR DESCRIPTION
Noticed that "components" was in the url also so it looked like the package is called "tegel components".