### PR TITLE
chore: bump @scania/tegel-angular to 1.35.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@angular/platform-browser": "^16.1.4",
         "@angular/platform-browser-dynamic": "^16.1.4",
         "@angular/router": "^16.1.4",
-        "@scania/tegel-angular": "^1.38.0",
+        "@scania/tegel-angular": "^1.35.0",
         "prettier": "^2.8.8",
         "rxjs": "~7.5.0",
         "tslib": "^2.3.0",
@@ -3903,11 +3903,11 @@
       }
     },
     "node_modules/@scania/tegel-angular": {
-      "version": "1.38.0",
-      "resolved": "https://registry.npmjs.org/@scania/tegel-angular/-/tegel-angular-1.38.0.tgz",
-      "integrity": "sha512-zZkWPhhBfjsJX7JfqJKEJ4zbudRM1LGXn2mTr1stdnrP1HW/iYMKb4GBduZ6cs9xn2HVFFMe96S32VHVVuW9JQ==",
+      "version": "1.35.0",
+      "resolved": "https://registry.npmjs.org/@scania/tegel-angular/-/tegel-angular-1.35.0.tgz",
+      "integrity": "sha512-AUjAt+jwMQ+sdPdtJuOMYW9DDzNYEY1QYvNzvze+/FPjJla0DDy6iDxDca8XMQiP/CqPWLR6W5SVvi47qltG2Q==",
       "dependencies": {
-        "@scania/tegel": "^1.38.0",
+        "@scania/tegel": "^1.35.0",
         "tslib": "^2.3.0"
       }
     },

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "@angular/platform-browser": "^16.1.4",
     "@angular/platform-browser-dynamic": "^16.1.4",
     "@angular/router": "^16.1.4",
-    "@scania/tegel-angular": "^1.38.0",
+    "@scania/tegel-angular": "^1.35.0",
     "prettier": "^2.8.8",
     "rxjs": "~7.5.0",
     "tslib": "^2.3.0",


### PR DESCRIPTION
Automated version bump for @scania/tegel-angular to 1.35.0

This PR was created automatically using the demo-bump git alias.

**Changes:**
- Updated @scania/tegel-angular to version 1.35.0
- All dependencies have been updated accordingly

**Testing:**
- [ ] Verify the application builds successfully
- [ ] Test the updated components
- [ ] Check for any breaking changes